### PR TITLE
chore(release): 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ MCP clients should launch the server over stdio with command: `flink-mcp`.
 Ensure `SQL_GATEWAY_API_BASE_URL` is set in your environment or `.env`.
 
 
-### Tools (v0.2.1)
+### Tools (v0.2.2)
 
 - `flink_info` (resource): returns cluster info from `/v3/info`.
 - `open_new_session(properties?: dict)` -> `{ sessionHandle, ... }`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flink-mcp"
-version = "0.2.1"
+version = "0.2.2"
 
 description = "MCP server for Apache Flink SQL Gateway"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -66,7 +66,7 @@ wheels = [
 
 [[package]]
 name = "flink-mcp"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
- Bump version to 0.2.2 in pyproject, README, server banner
- Compact run_query_collect_and_stop: return {columns, data}, stop at max_rows
- Refresh uv.lock via uv lock --refresh